### PR TITLE
Bump alpine from 3.16 to 3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 LABEL maintainer="Don <novaspirit@novaspirit.com>"
 


### PR DESCRIPTION
Bumps alpine from 3.16 to 3.17.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...